### PR TITLE
Fix jalali day of the week return problem

### DIFF
--- a/src/Datium.php
+++ b/src/Datium.php
@@ -160,7 +160,6 @@ class Datium
         $this->gregorian_DayofWeek = $this->date_time->format('w');
 
         $this->convert_calendar = new Convert();
-
     }
 
     /**
@@ -477,6 +476,8 @@ class Datium
             new DateInterval($this->date_interval_expression)
         );
 
+        $this->gregorian_DayofWeek = $this->date_time->format('w');
+        
         return $this;
 
     }
@@ -590,7 +591,7 @@ class Datium
     public function get($format = 'Y-m-d H:i:s')
     {
 
-        if( $format === 'timestamp' ) {
+        if ($format === 'timestamp') {
 
           return $this->timestamp();
 

--- a/tests/DatiumTest.php
+++ b/tests/DatiumTest.php
@@ -252,4 +252,12 @@ class DatiumTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Saturday 25th June 2016 12:00:00 PM', $gregorian);
 
     }
+
+    public function testJalaliSubDateTime()
+    {
+        $jalali = Datium::create(2017, 9, 1, 12, 0, 0)->sub('1 day')->to('jalali')
+                        ->get('l jS F Y h:i:s');
+
+        $this->assertEquals("Panjshanbe 9th Shahrivar 1396 12:00:00", $jalali);
+    }
 }


### PR DESCRIPTION
Fixed problem of return day of the week when used sub method to sub from date and convert it to jalali, fixed it by get current day of the week on sub method.